### PR TITLE
Updated ScalaTest 3.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,8 @@ lazy val scalacheck = (project in file("."))
       %%("scalacheck", V.scalacheck),
       %%("shapeless", V.shapeless),
       "com.github.alexarchambault" %% "scalacheck-shapeless_1.14"   % V.scalacheckShapeless,
-      "com.47deg"                  %% "scalacheck-toolbox-datetime" % V.scalacheckDatetime
+      "com.47deg"                  %% "scalacheck-toolbox-datetime" % V.scalacheckDatetime,
+      "org.scalatestplus"          %% "scalatestplus-scalacheck"    % V.scalatestplusScheck
     )
   )
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -17,7 +17,8 @@ object ProjectPlugin extends AutoPlugin {
     lazy val V = new {
       val scala212: String            = "2.12.10"
       val shapeless: String           = "2.3.3"
-      val scalatest: String           = "3.0.8"
+      val scalatest: String           = "3.1.0"
+      val scalatestplusScheck: String = "3.1.0.0-RC2"
       val scalacheck: String          = "1.14.2"
       val scalacheckShapeless: String = "1.2.3"
       val scalacheckDatetime: String  = "0.3.1"

--- a/src/main/scala/scalachecklib/ArbitrarySection.scala
+++ b/src/main/scala/scalachecklib/ArbitrarySection.scala
@@ -6,7 +6,7 @@
 
 package scalachecklib
 
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.Checkers
 
 /** ==The `arbitrary` Generator==

--- a/src/main/scala/scalachecklib/GeneratorsSection.scala
+++ b/src/main/scala/scalachecklib/GeneratorsSection.scala
@@ -6,7 +6,7 @@
 
 package scalachecklib
 
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.Checkers
 
 /** Generators are responsible for generating test data in ScalaCheck, and are represented by the `org.scalacheck.Gen`

--- a/src/main/scala/scalachecklib/PropertiesSection.scala
+++ b/src/main/scala/scalachecklib/PropertiesSection.scala
@@ -6,7 +6,7 @@
 
 package scalachecklib
 
-import org.scalatest._
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.Checkers
 
 /** A ''property'' is the testable unit in ScalaCheck, and is represented by the `org.scalacheck.Prop` class.

--- a/src/main/scala/scalachecklib/ScalacheckDatetimeSection.scala
+++ b/src/main/scala/scalachecklib/ScalacheckDatetimeSection.scala
@@ -6,7 +6,7 @@
 
 package scalachecklib
 
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.Checkers
 
 /** scalacheck-datetime is a library for helping use datetime libraries with ScalaCheck

--- a/src/test/scala/scalachecklib/ArbitrarySpec.scala
+++ b/src/test/scala/scalachecklib/ArbitrarySpec.scala
@@ -8,11 +8,11 @@ package scalachecklib
 
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
-class ArbitrarySpec extends FunSuite with Checkers {
+class ArbitrarySpec extends AnyFunSuite with Checkers {
 
   test("implicit arbitrary char") {
 

--- a/src/test/scala/scalachecklib/GeneratorsSpec.scala
+++ b/src/test/scala/scalachecklib/GeneratorsSpec.scala
@@ -8,11 +8,11 @@ package scalachecklib
 
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
-class GeneratorsSpec extends FunSuite with Checkers {
+class GeneratorsSpec extends AnyFunSuite with Checkers {
 
   test("for-comprehension generator") {
 

--- a/src/test/scala/scalachecklib/PropertiesSpec.scala
+++ b/src/test/scala/scalachecklib/PropertiesSpec.scala
@@ -8,11 +8,11 @@ package scalachecklib
 
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
-class PropertiesSpec extends FunSuite with Checkers {
+class PropertiesSpec extends AnyFunSuite with Checkers {
 
   test("always ends with the second string") {
 

--- a/src/test/scala/scalachecklib/ScalacheckDatetimeSpec.scala
+++ b/src/test/scala/scalachecklib/ScalacheckDatetimeSpec.scala
@@ -8,11 +8,11 @@ package scalachecklib
 
 import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
-class ScalacheckDatetimeSpec extends FunSuite with Checkers {
+class ScalacheckDatetimeSpec extends AnyFunSuite with Checkers {
 
   test("simple usage") {
 


### PR DESCRIPTION
This PR updates ScalaTest dependency to 3.1.0 version.