### PR TITLE
Update scalacheck-toolbox-datetime

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,7 @@ lazy val scalacheck = (project in file("."))
       %%("scalatest", V.scalatest),
       %%("scalacheck", V.scalacheck),
       %%("shapeless", V.shapeless),
+      "joda-time" % "joda-time" % V.jodaTime,
       "com.github.alexarchambault" %% "scalacheck-shapeless_1.14"   % V.scalacheckShapeless,
       "com.47deg"                  %% "scalacheck-toolbox-datetime" % V.scalacheckDatetime,
       "org.scalatestplus"          %% "scalatestplus-scalacheck"    % V.scalatestplusScheck

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -21,7 +21,8 @@ object ProjectPlugin extends AutoPlugin {
       val scalatestplusScheck: String = "3.1.0.0-RC2"
       val scalacheck: String          = "1.14.2"
       val scalacheckShapeless: String = "1.2.3"
-      val scalacheckDatetime: String  = "0.3.1"
+      val scalacheckDatetime: String  = "0.3.2"
+      val jodaTime: String            = "2.10.5"
     }
   }
 


### PR DESCRIPTION
This PR updates the `scalacheck-toolbox-datetime` library to `0.3.2` version.