### PR TITLE
Compile when Publish

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,8 @@
+import com.jsuereth.sbtpgp.PgpKeys.publishSigned
+
+publishLocal := (publishLocal dependsOn compile).value
+publishSigned := (publishSigned dependsOn compile).value
+
 addCommandAlias("ci-test", "scalafmtCheckAll; scalafmtSbtCheck; test")
 addCommandAlias("ci-docs", "github; project-docs/mdoc; headerCreateAll")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 resolvers += Resolver.sonatypeRepo("snapshots")
-addSbtPlugin("org.scala-exercises" % "sbt-exercise"      % "0.6.0-SNAPSHOT")
+addSbtPlugin("org.scala-exercises" % "sbt-exercise"      % "0.6.0")
 addSbtPlugin("com.geirsson"        % "sbt-ci-release"    % "1.5.3")
 addSbtPlugin("org.scalameta"       % "sbt-mdoc"          % "2.1.5")
 addSbtPlugin("org.scalameta"       % "sbt-scalafmt"      % "2.3.4")


### PR DESCRIPTION
This PR makes that in every publish (publishLocal or publishSigned), the exercises are compiled, which it's a requirement for scala-exercises.

Additionally, a stable version of the sbt plugin is used.